### PR TITLE
Canvas is no longer nullable

### DIFF
--- a/android/src/main/kotlin/com/shopify/reactnative/flash_list/AutoLayoutView.kt
+++ b/android/src/main/kotlin/com/shopify/reactnative/flash_list/AutoLayoutView.kt
@@ -26,7 +26,7 @@ class AutoLayoutView(context: Context) : ReactViewGroup(context) {
 
     /** Overriding draw instead of onLayout. RecyclerListView uses absolute positions for each and every item which means that changes in child layouts may not trigger onLayout on this container. The same layout
      * can still cause views to overlap. Therefore, it makes sense to override draw to do correction. */
-    override fun dispatchDraw(canvas: Canvas?) {
+    override fun dispatchDraw(canvas: Canvas) {
         fixLayout()
         fixFooter()
         super.dispatchDraw(canvas)


### PR DESCRIPTION
## Description

Fixes
- `Type mismatch: inferred type is Canvas? but Canvas was expected`

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ]

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
